### PR TITLE
Add custom spawn eggs to vanilla SpawnEggItem.BY_ID map

### DIFF
--- a/src/main/java/com/anonymoushacker1279/immersiveweapons/item/CustomSpawnEggItem.java
+++ b/src/main/java/com/anonymoushacker1279/immersiveweapons/item/CustomSpawnEggItem.java
@@ -1,15 +1,25 @@
 package com.anonymoushacker1279.immersiveweapons.item;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import javax.annotation.Nullable;
+
+import com.anonymoushacker1279.immersiveweapons.ImmersiveWeapons;
+
 import net.minecraft.entity.EntityType;
 import net.minecraft.item.SpawnEggItem;
 import net.minecraft.nbt.CompoundNBT;
 import net.minecraftforge.common.util.Lazy;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.RegistryObject;
+import net.minecraftforge.fml.common.Mod.EventBusSubscriber;
+import net.minecraftforge.fml.common.Mod.EventBusSubscriber.Bus;
+import net.minecraftforge.fml.common.ObfuscationReflectionHelper;
+import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
 
-import javax.annotation.Nullable;
-import java.util.ArrayList;
-import java.util.List;
-
+@EventBusSubscriber(modid = ImmersiveWeapons.MOD_ID, bus = Bus.MOD)
 public class CustomSpawnEggItem extends SpawnEggItem {
 
 	protected static final List<CustomSpawnEggItem> UNADDED_EGGS = new ArrayList<>();
@@ -26,5 +36,18 @@ public class CustomSpawnEggItem extends SpawnEggItem {
 	public EntityType<?> getType(@Nullable final CompoundNBT p_208076_1_) {
 		return entityTypeSupplier.get();
 	}
-
+	
+    @SubscribeEvent
+    public static void setup(FMLCommonSetupEvent event) {
+        event.enqueueWork(() -> {
+            try {
+                Map<EntityType<?>, SpawnEggItem> eggs = ObfuscationReflectionHelper.getPrivateValue(SpawnEggItem.class,
+                        null, "field_195987_b");
+                for (CustomSpawnEggItem egg : UNADDED_EGGS)
+                    eggs.put(egg.entityTypeSupplier.get(), egg);
+            } catch (Exception e) {
+                ImmersiveWeapons.LOGGER.warn("Unable to access SpawnEggItem.BY_ID");
+            }
+        });
+    }
 }


### PR DESCRIPTION
This change uses reflection to access the vanilla SpawnEggItem.BY_ID map
and add the mod spawn eggs to that map. This means that players in
creative mode will now be able to middle click the mod entities to get
the spawn eggs (like the vanilla entities). This also means that other
mods will be able to query the BY_ID map to get the spawn eggs from this
mod.