### PR TITLE
Update README, MODS.TOML, and update.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,43 @@
 ![Immersive Weapons Logo](logo.png)
 
 # Immersive Weapons for Minecraft 1.16.5
+
 ![CodeQL](https://github.com/AnonymousHacker1279/ImmersiveWeapons-Mod/workflows/CodeQL/badge.svg)
 [![](http://cf.way2muchnoise.eu/full_494454_Downloads.svg)](https://www.curseforge.com/minecraft/mc-mods/immersive-weapons)
 [![](http://cf.way2muchnoise.eu/versions/494454_latest.svg)](https://www.curseforge.com/minecraft/mc-mods/immersive-weapons)
-## A vanilla+ weapons mod for Minecraft 1.16.5/1.16.4/1.15.2
-Active development is focused on the 1.16.x branch. Please only use old releases if necessary. Support will not be provided for old releases. 
 
-Note that the 1.16.5 version will work on 1.16.4 as well. 
+## A vanilla+ weapons mod for Minecraft 1.16.5/1.16.4/1.15.2
+
+Immersive Weapons is a vanilla+ weapons add-on aiming to spice up your combat skills.
+
+Traverse the world, scavenging in destroyed factories or climbing to the pits of hell to collect new and powerful
+resources. Build stronger and more versatile weapons of war. Fortify your base and sound alarms at the first sign of
+intrusion by invaders.
+
+A few things that will be the highlight of your experience:
+
+- Tiered Pikes, so you can stab someone from way over there
+- Flintlock Pistol and Blunderbuss, so you can shoot someone from way over there
+- New and Powerful Swords, so you can slice someone that isn't way over there
+- Medical Equipment, so you can survive getting stabbed, shot, and sliced
+- Environmental Traps, so you can stop people from coming over to stab, shoot, and slice you
+
+A few other notes:
+
+- I only intend to work on the latest versions of Minecraft. Don't ask about porting to old versions.
+- This is for the Forge modloading platform. No, I don't plan to port to Fabric, don't ask about it.
+- Yes, you can include it in modpacks, provided it is open source and doesn't have an installer.
+- This is open source. If you want to port to old versions or to Fabric, do it yourself.
+
+[Interested in coding, or just want to hang out? Join my Discord server: Titan Programming](https://discord.gg/hjvZfAu7sB)
+
+Active development will be focused on the latest Minecraft version. Please only use old releases if necessary. Support
+will not be provided for old releases.
+
+| MC Version | Immersive Weapons Version Support |
+| :-- | :-- |
+| 1.16.5 | [Latest](https://github.com/AnonymousHacker1279/ImmersiveWeapons/releases) |
+| 1.16.4 | [1.1.1](https://github.com/AnonymousHacker1279/ImmersiveWeapons/releases/tag/v1.1.1) |
+| 1.15.2 | [N/A - Build From Source](https://github.com/AnonymousHacker1279/ImmersiveWeapons/tree/1.15.2-dev) |
 
 Please report any bugs/suggestions to the issue tracker. If you would like to contribute please fork this repository and make a pull request.

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -1,5 +1,5 @@
 modLoader = "javafml" #mandatory
-loaderVersion = "[35,)" #mandatory
+loaderVersion = "[36,)" #mandatory
 license = "MIT"
 issueTrackerURL = "https://github.com/AnonymousHacker1279/ImmersiveWeapons/issues" #optional
 
@@ -19,13 +19,13 @@ Immersive Weapons is a vanilla+ weapons add-on aiming to spice up your combat sk
 [[dependencies.immersiveweapons]] #optional
 modId = "forge" #mandatory
 mandatory = true #mandatory
-versionRange = "[35,)" #mandatory
+versionRange = "[36,)" #mandatory
 ordering = "NONE"
 side = "BOTH"
 
 [[dependencies.immersiveweapons]]
 modId = "minecraft"
 mandatory = true
-versionRange = "[1.16.4,1.17)"
+versionRange = "[1.16.5,1.17)"
 ordering = "NONE"
 side = "BOTH"

--- a/update.json
+++ b/update.json
@@ -3,8 +3,8 @@
 	"promos": {
 		"1.16.5-latest": "1.3.0",
 		"1.16.5-recommended": "1.3.0",
-		"1.16.4-latest": "1.3.0",
-		"1.16.4-recommended": "1.3.0"
+		"1.16.4-latest": "1.1.1",
+		"1.16.4-recommended": "1.1.1"
 	},
 	"1.16.5": {
 		"1.3.0": "Additions, improvements, bugfixes - https://github.com/AnonymousHacker1279/ImmersiveWeapons/releases/tag/v1.3.0",
@@ -27,8 +27,6 @@
 		"0.6.0": "Additions, improvements, bugfixes - https://github.com/AnonymousHacker1279/ImmersiveWeapons/releases/tag/v0.6.x"
 	},
 	"1.16.4": {
-		"1.3.0": "Additions, improvements, bugfixes - https://github.com/AnonymousHacker1279/ImmersiveWeapons/releases/tag/v1.3.0",
-		"1.2.0": "Additions, improvements, bugfixes - https://github.com/AnonymousHacker1279/ImmersiveWeapons/releases/tag/v1.2.0",
 		"1.1.1": "Bugfixes - https://github.com/AnonymousHacker1279/ImmersiveWeapons/releases/tag/v1.1.1",
 		"1.1.0": "Additions and improvements - https://github.com/AnonymousHacker1279/ImmersiveWeapons/releases/tag/v1.1.0",
 		"1.0.6": "Improvements - https://github.com/AnonymousHacker1279/ImmersiveWeapons/releases/tag/v1.0.6",


### PR DESCRIPTION
Update the README with information from the CurseForge page, and add a table showing supported versions.

Update MODS.TOML to only allow 1.16.5 on the current build. Java 16 on 1.16.x doesn't work on 1.16.4. The previous release will still attempt to load on 1.16.4, although it is not compatible.