### PR TITLE
Implement WTHIT support (a fork of HWYLA)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,10 @@ repositories {
 		name "Maven Central"
 		url "https://repo.maven.apache.org/maven2"
 	}
+	maven {
+		name "Bai Maven"
+		url "https://maven.bai.lol"
+	}
 }
 
 // Only edit below this line, the above code adds and enables the necessary things for Forge to be setup.
@@ -31,7 +35,7 @@ apply plugin: 'net.minecraftforge.gradle'
 apply plugin: 'org.parchmentmc.librarian.forgegradle'
 apply plugin: 'maven-publish'
 
-version = '1.17.1-1.8.3'
+version = '1.17.1-1.8.4'
 group = 'com.anonymoushacker1279.immersiveweapons' // http://maven.apache.org/guides/mini/guide-naming-conventions.html
 
 java.toolchain.languageVersion = JavaLanguageVersion.of(16)
@@ -108,12 +112,13 @@ dependencies {
 	// Specify the version of Minecraft to use, If this is any group other then 'net.minecraft' it is assumed
 	// that the dep is a ForgeGradle 'patcher' dependency. And it's patches will be applied.
 	// The userdev artifact is a special name and will get all sorts of transformations applied to it.
-	minecraft 'net.minecraftforge:forge:1.17.1-37.0.45'
+	minecraft 'net.minecraftforge:forge:1.17.1-37.0.47'
 
-	// compile against the JEI API but do not include it at runtime
-	compileOnly fg.deobf("mezz.jei:jei-1.17.1:8.0.0.14:api")
-	// at runtime, use the full JEI jar
-	runtimeOnly fg.deobf("mezz.jei:jei-1.17.1:8.0.0.14")
+	// Include JEI
+	implementation fg.deobf("mezz.jei:jei-1.17.1:8.0.0.14")
+
+	// Include WTHIT
+	implementation fg.deobf("mcp.mobius.waila:wthit:forge-3.8.1")
 }
 
 // Example for how to get properties into the manifest for reading by the runtime..

--- a/src/main/java/com/anonymoushacker1279/immersiveweapons/client/integration/waila/ImmersiveWeaponsWailaPlugin.java
+++ b/src/main/java/com/anonymoushacker1279/immersiveweapons/client/integration/waila/ImmersiveWeaponsWailaPlugin.java
@@ -1,0 +1,16 @@
+package com.anonymoushacker1279.immersiveweapons.client.integration.waila;
+
+import com.anonymoushacker1279.immersiveweapons.ImmersiveWeapons;
+import com.anonymoushacker1279.immersiveweapons.block.trap.PitfallBlock;
+import com.anonymoushacker1279.immersiveweapons.client.integration.waila.overrides.PitfallBlockOverride;
+import mcp.mobius.waila.api.IRegistrar;
+import mcp.mobius.waila.api.IWailaPlugin;
+import mcp.mobius.waila.api.WailaPlugin;
+
+@WailaPlugin(id = ImmersiveWeapons.MOD_ID + ":waila_plugin")
+public class ImmersiveWeaponsWailaPlugin implements IWailaPlugin {
+	@Override
+	public void register(IRegistrar registrar) {
+		registrar.addOverride(new PitfallBlockOverride(), PitfallBlock.class);
+	}
+}

--- a/src/main/java/com/anonymoushacker1279/immersiveweapons/client/integration/waila/overrides/PitfallBlockOverride.java
+++ b/src/main/java/com/anonymoushacker1279/immersiveweapons/client/integration/waila/overrides/PitfallBlockOverride.java
@@ -1,0 +1,14 @@
+package com.anonymoushacker1279.immersiveweapons.client.integration.waila.overrides;
+
+import mcp.mobius.waila.api.IBlockAccessor;
+import mcp.mobius.waila.api.IBlockComponentProvider;
+import mcp.mobius.waila.api.IPluginConfig;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.state.BlockState;
+
+public class PitfallBlockOverride implements IBlockComponentProvider {
+	@Override
+	public BlockState getOverride(IBlockAccessor accessor, IPluginConfig config) {
+		return Blocks.GRASS_BLOCK.defaultBlockState();
+	}
+}

--- a/src/main/java/com/anonymoushacker1279/immersiveweapons/item/utility/CustomSpawnEggItem.java
+++ b/src/main/java/com/anonymoushacker1279/immersiveweapons/item/utility/CustomSpawnEggItem.java
@@ -5,6 +5,7 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.item.SpawnEggItem;
+import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.common.util.Lazy;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod.EventBusSubscriber;
@@ -19,7 +20,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-@EventBusSubscriber(modid = ImmersiveWeapons.MOD_ID, bus = Bus.MOD)
+@EventBusSubscriber(modid = ImmersiveWeapons.MOD_ID, bus = Bus.MOD, value = Dist.CLIENT)
 public class CustomSpawnEggItem extends SpawnEggItem {
 
 	private static final List<CustomSpawnEggItem> UNADDED_EGGS = new ArrayList<>(1);
@@ -59,7 +60,7 @@ public class CustomSpawnEggItem extends SpawnEggItem {
             try {
                 Map<EntityType<?>, SpawnEggItem> spawnEggItemMap = ObfuscationReflectionHelper.getPrivateValue(SpawnEggItem.class,
                         null, "f_43201_");
-                Minecraft minecraft = Minecraft.getInstance();
+	            Minecraft minecraft = Minecraft.getInstance();
 	            for (CustomSpawnEggItem spawnEggItem : UNADDED_EGGS) {
 		            if (spawnEggItemMap != null) {
 			            spawnEggItemMap.put(spawnEggItem.entityTypeSupplier.get(), spawnEggItem);

--- a/update.json
+++ b/update.json
@@ -1,14 +1,15 @@
 {
 	"homepage": "https://www.curseforge.com/minecraft/mc-mods/immersive-weapons",
 	"promos": {
-		"1.17.1-latest": "1.17.1-1.8.3",
-		"1.17.1-recommended": "1.17.1-1.8.3",
+		"1.17.1-latest": "1.17.1-1.8.4",
+		"1.17.1-recommended": "1.17.1-1.8.4",
 		"1.16.5-latest": "1.16.5-1.4.2",
 		"1.16.5-recommended": "1.16.5-1.4.2",
 		"1.16.4-latest": "1.16.5-1.1.1",
 		"1.16.4-recommended": "1.16.5-1.1.1"
 	},
 	"1.17.1": {
+		"1.17.1-1.8.4": "Improvements - https://github.com/AnonymousHacker1279/ImmersiveWeapons/releases/tag/v1.8.4",
 		"1.17.1-1.8.3": "Improvements - https://github.com/AnonymousHacker1279/ImmersiveWeapons/releases/tag/v1.8.3",
 		"1.17.1-1.8.2": "New language translations - https://github.com/AnonymousHacker1279/ImmersiveWeapons/releases/tag/v1.8.2",
 		"1.17.1-1.8.1": "Bugfixes - https://github.com/AnonymousHacker1279/ImmersiveWeapons/releases/tag/v1.8.1",


### PR DESCRIPTION
Implement WTHIT support, which is a fork of HWYLA, which is a fork of Waila. Support is relatively simple, only masking pitfall blocks as normal grass blocks.

Better distribution safety in CustomSpawnEggItem, which also fixes warnings on dedicated servers.