### PR TITLE
Add missing loot tables

### DIFF
--- a/src/main/resources/data/immersiveweapons/loot_tables/blocks/hardened_mud_slab.json
+++ b/src/main/resources/data/immersiveweapons/loot_tables/blocks/hardened_mud_slab.json
@@ -1,0 +1,14 @@
+{
+	"type": "minecraft:block",
+	"pools": [
+		{
+			"rolls": 1,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"name": "immersiveweapons:hardened_mud_slab"
+				}
+			]
+		}
+	]
+}

--- a/src/main/resources/data/immersiveweapons/loot_tables/blocks/hardened_mud_stairs.json
+++ b/src/main/resources/data/immersiveweapons/loot_tables/blocks/hardened_mud_stairs.json
@@ -1,0 +1,14 @@
+{
+	"type": "minecraft:block",
+	"pools": [
+		{
+			"rolls": 1,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"name": "immersiveweapons:hardened_mud_stairs"
+				}
+			]
+		}
+	]
+}

--- a/src/main/resources/data/immersiveweapons/loot_tables/blocks/warrior_statue_base.json
+++ b/src/main/resources/data/immersiveweapons/loot_tables/blocks/warrior_statue_base.json
@@ -1,0 +1,14 @@
+{
+	"type": "minecraft:block",
+	"pools": [
+		{
+			"rolls": 1,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"name": "immersiveweapons:warrior_statue_base"
+				}
+			]
+		}
+	]
+}

--- a/src/main/resources/data/immersiveweapons/loot_tables/blocks/warrior_statue_head.json
+++ b/src/main/resources/data/immersiveweapons/loot_tables/blocks/warrior_statue_head.json
@@ -1,0 +1,14 @@
+{
+	"type": "minecraft:block",
+	"pools": [
+		{
+			"rolls": 1,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"name": "immersiveweapons:warrior_statue_head"
+				}
+			]
+		}
+	]
+}

--- a/src/main/resources/data/immersiveweapons/loot_tables/blocks/warrior_statue_torso.json
+++ b/src/main/resources/data/immersiveweapons/loot_tables/blocks/warrior_statue_torso.json
@@ -1,0 +1,58 @@
+{
+	"pools": [
+		{
+			"rolls": 1,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"name": "immersiveweapons:azul_keystone"
+				}
+			],
+			"conditions": [
+				{
+					"condition": "minecraft:block_state_property",
+					"block": "immersiveweapons:warrior_statue_torso",
+					"properties": {
+						"powered": "true"
+					}
+				}
+			]
+		},
+		{
+			"rolls": 1,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"name": "immersiveweapons:warrior_statue_torso"
+				}
+			],
+			"conditions": [
+				{
+					"condition": "minecraft:block_state_property",
+					"block": "immersiveweapons:warrior_statue_torso",
+					"properties": {
+						"powered": "true"
+					}
+				}
+			]
+		},
+		{
+			"rolls": 1,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"name": "immersiveweapons:warrior_statue_torso"
+				}
+			],
+			"conditions": [
+				{
+					"condition": "minecraft:block_state_property",
+					"block": "immersiveweapons:warrior_statue_torso",
+					"properties": {
+						"powered": "false"
+					}
+				}
+			]
+		}
+	]
+}

--- a/update.json
+++ b/update.json
@@ -1,14 +1,15 @@
 {
 	"homepage": "https://www.curseforge.com/minecraft/mc-mods/immersive-weapons",
 	"promos": {
-		"1.17.1-latest": "1.17.1-1.12.0",
-		"1.17.1-recommended": "1.17.1-1.12.0",
+		"1.17.1-latest": "1.17.1-1.12.1",
+		"1.17.1-recommended": "1.17.1-1.12.1",
 		"1.16.5-latest": "1.16.5-1.4.2",
 		"1.16.5-recommended": "1.16.5-1.4.2",
 		"1.16.4-latest": "1.16.5-1.1.1",
 		"1.16.4-recommended": "1.16.5-1.1.1"
 	},
 	"1.17.1": {
+		"1.17.1-1.12.1": "Bugfixes - https://github.com/AnonymousHacker1279/ImmersiveWeapons/releases/tag/v1.12.1",
 		"1.17.1-1.12.0": "Features, improvements and bugfixes - https://github.com/AnonymousHacker1279/ImmersiveWeapons/releases/tag/v1.12.0",
 		"1.17.1-1.11.0": "Features, improvements and bugfixes - https://github.com/AnonymousHacker1279/ImmersiveWeapons/releases/tag/v1.11.0",
 		"1.17.1-1.10.0": "Features, improvements and bugfixes - https://github.com/AnonymousHacker1279/ImmersiveWeapons/releases/tag/v1.10.0",


### PR DESCRIPTION
Add missing loot tables to the following blocks:
- Hardened Mud Slab
- Hardened Mud Stairs
- Warrior Statue Base
- Warrior Statue Torso
- Warrior Statue Head

Bump version in update.json